### PR TITLE
Property allowLegacyListeners not required

### DIFF
--- a/joomla_extensions_development.xml
+++ b/joomla_extensions_development.xml
@@ -9441,10 +9441,8 @@ $results = $event-&gt;getArgument('result', []);</programlisting>
         <para>Plugins of this type are just like <link
         linkend="plg-forms-j4-classic">Joomla 4 classic plugins</link> with a
         twist. The plugin class implements the
-        <interfacename>\Joomla\Event\SubscriberInterface</interfacename> and
-        you set the protected property <code>$this-&gt;allowLegacyListeners =
-        false;</code>. This changes the way Joomla registers event
-        handlers.</para>
+        <interfacename>\Joomla\Event\SubscriberInterface</interfacename>.
+        This changes the way Joomla registers event handlers.</para>
 
         <para>Joomla will NOT use reflection to find public methods whose name
         starts with <code>on</code>. It will instead call the public static


### PR DESCRIPTION
### Summary of Changes

Adjustment in _Plugins with SubscriberInterface_

### Reasoning

I think `set the protected property $allowLegacyListeners to false` is not required when the plugins implements the SubscriberInterface because of the early return in line 200 while the listeners are being registered.

https://github.com/joomla/joomla-cms/blob/dc83b7001ff81d64cefd3f34efac56d47a90695a/libraries/src/Plugin/CMSPlugin.php#L194-L217