### PR TITLE
Model naming consistency.

### DIFF
--- a/joomla_extensions_development.xml
+++ b/joomla_extensions_development.xml
@@ -3419,7 +3419,7 @@ class Dispatcher extends \Joomla\CMS\Dispatcher\ComponentDispatcher
           <term>Joomla\CMS\MVC\Model\ItemModel</term>
 
           <listitem>
-            <para>This is an extension of the DatabaseModel, designed to
+            <para>This is an extension of the BaseDatabaseModel, designed to
             <emphasis>display</emphasis> a single record in the
             frontend.</para>
 
@@ -3447,7 +3447,7 @@ class Dispatcher extends \Joomla\CMS\Dispatcher\ComponentDispatcher
           <term>Joomla\CMS\MVC\Model\ListModel</term>
 
           <listitem>
-            <para>This class extends from the DatabaseModel and has the
+            <para>This class extends from the BaseDatabaseModel and has the
             ability to manage forms (you need them for Search Tools a.k.a.
             list filters) and, crucially, to provide pagination-aware list of
             records from a database table.</para>


### PR DESCRIPTION
Pull Request for Issue #7.

### Summary of Changes

Renames DatabaseModel to `BaseDatabaseModel`. 

### Reasoning

In the `ItemModel` and `ListModel` descriptions of [Chapter 2: Components - Models](https://www.dionysopoulos.me/book/com-models.html), you refer to "DatabaseModel". For consistency with the preceding sections on that page, I think it makes sense to rename those to `BaseDatabasModel`.

@nikosdion You closed the issue, either because you did not agree with my suggestion or because you assumed it was part of another PR, which it wasn't (my fault). I guess the latter, so I created this PR. If it turns out to be the former, ignore the PR and accept my apologies for misunderstanding.