### PR TITLE
Assumed copy paste error correction

### DIFF
--- a/joomla_extensions_development.xml
+++ b/joomla_extensions_development.xml
@@ -4882,10 +4882,12 @@ class Example {
       <programlisting language="php">&lt;?php
 namespace Acme\Example\Administrator\Extension;
 
+use Acme\Example\Administrator\Service\Html\Example;
+
 class Example extends MVCComponent implements BootableExtensionInterface {
     public function boot(ContainerInterface $container)
     {
-        $this-&gt;getRegistry()-&gt;register('ats', new ATS());
+        $this-&gt;getRegistry()-&gt;register('example', new Example());
     }
 }</programlisting>
 
@@ -4921,11 +4923,13 @@ class Example {
       <programlisting language="php">&lt;?php
 namespace Acme\Example\Administrator\Extension;
 
+use Acme\Example\Administrator\Service\Html\Example;
+
 class Example extends MVCComponent implements BootableExtensionInterface {
     public function boot(ContainerInterface $container)
     {
         <emphasis role="bold">$db = $container-&gt;get('DatabaseDriver');</emphasis>
-        $this-&gt;getRegistry()-&gt;register('ats', new ATS(<emphasis
+        $this-&gt;getRegistry()-&gt;register('example', new Example(<emphasis
           role="bold">$db</emphasis>));
     }
 }</programlisting>


### PR DESCRIPTION
### Summary of Changes

1. Replaces references to `ATS` with references to Acme's `Example`.
1. Adds `Example` service import

### Reasoning

1. The docs first describes creation of service `Acme\Example\Administrator\Service\Html\Example` but continues with references to `Akeeba\Component\ATS\Administrator\Service\Html\ATS`. This looks like a typical copy & paste oversight.
1. I think the code is just a little bit more explanitory, if the import of the used service class is explicitly mentioned.